### PR TITLE
Fix a typo in slides for lecture 04

### DIFF
--- a/slides/04/04.md
+++ b/slides/04/04.md
@@ -170,7 +170,8 @@ $$(⇉I \* ⇉K)\_{i, j, k} = ∑\_{m, n, o} ⇉I\_{i\cdot S + m, j\cdot S + n, 
 --
 
 There are multiple padding schemes, most common are:
-- `valid`: we only use valid pixels, which causes the result to me smaller
+- `valid`: we only use valid pixels, which causes the result to be smaller
+  than the input
 - `same`: we pad original image with zero pixels so that the result is exactly
   the size of the input
 


### PR DESCRIPTION
Maybe it should be also specified that the result is only smaller than the input if **W** or **H** are larger than one. Although this obviously has to be the case if the convolution should be meaningful :)