### PR TITLE
Add batches for test data predicts.

### DIFF
--- a/labs/06/3d_recognition.py
+++ b/labs/06/3d_recognition.py
@@ -3,12 +3,13 @@ import numpy as np
 import tensorflow as tf
 
 class Dataset:
-    def __init__(self, filename):
+    def __init__(self, filename, shuffle_batches = True):
         data = np.load(filename)
         self._voxels = data["voxels"]
         self._labels = data["labels"] if "labels" in data else None
 
-        self._permutation = np.random.permutation(len(self._voxels))
+        self._shuffle = shuffle_batches
+        self._permutation = np.random.permutation(len(self._voxels)) if self._shuffle else range(len(self._voxels))
 
     def split(self, ratio):
         split = int(len(self._voxels) * ratio)
@@ -36,9 +37,14 @@ class Dataset:
         batch_perm, self._permutation = self._permutation[:batch_size], self._permutation[batch_size:]
         return self._voxels[batch_perm], self._labels[batch_perm]
 
+    def next_batch_data_for_prediction(self, batch_size):
+        batch_size = min(batch_size, len(self._permutation))
+        batch_perm, self._permutation = self._permutation[:batch_size], self._permutation[batch_size:]
+        return self._voxels[batch_perm]
+
     def epoch_finished(self):
         if len(self._permutation) == 0:
-            self._permutation = np.random.permutation(len(self._voxels))
+            self._permutation = np.random.permutation(len(self._voxels)) if self._shuffle else range(len(self._voxels))
             return True
         return False
 
@@ -124,7 +130,7 @@ if __name__ == "__main__":
 
     # Load the data
     train, dev = Dataset("modelnet{}-train.npz".format(args.modelnet_dim)).split(args.train_split)
-    test = Dataset("modelnet{}-test.npz".format(args.modelnet_dim))
+    test = Dataset("modelnet{}-test.npz".format(args.modelnet_dim), shuffle_batches=False)
 
     # Construct the network
     network = Network(threads=args.threads)
@@ -140,5 +146,9 @@ if __name__ == "__main__":
 
     labels = network.predict(test.voxels)
     with open("3d_recognition_test.txt", "w") as test_file:
-        for label in labels:
-            print(label, file=test_file)
+        while not test.epoch_finished():
+            voxels = test.next_batch_data_for_prediction(args.batch_size)
+            labels = network.predict(voxels)
+
+            for label in labels:
+                print(label, file=test_file)


### PR DESCRIPTION
Predicting all data at once OOM'ed on fashion_masks task with larger networks. This fixes it (I can provide similar PR for fashion_mask as well). 

BTW: I have a few other quality-of-life improvements such as explicit file_name arg. that gets prefixed to the predicted result file etc. Should I create PRs for them as well or are the templates purposefully barebones?