### PR TITLE
Fix L1 norm update

### DIFF
--- a/slides/03/03.md
+++ b/slides/03/03.md
@@ -303,7 +303,7 @@ Similar to L2 regularization, but we prefer low L1 metric of parameters. We
 therefore minimize
 $$\tilde J(→θ; \mathbb X) = J(→θ; \mathbb X) + λ ||→θ||\_1$$
 
-The corresponding SGD update is then $$θ\_i ← θ\_i - α\frac{∂J}{∂θ\_i} - αλ.$$
+The corresponding SGD update is then $$θ\_i ← θ\_i - α\frac{∂J}{∂θ\_i} - \operatorname{sign}(θ\_i)αλ.$$
 
 ---
 # Regularization – Dataset Augmentation


### PR DESCRIPTION
Without signum, the thetas would simply be pushed into negative values.