### PR TITLE
Fix typo in convolution layer description

### DIFF
--- a/slides/04/04.md
+++ b/slides/04/04.md
@@ -164,7 +164,7 @@ several of them at the same time.
 
 Consider an input image with $C$ channels. The convolution layer with
 $F$ filters of width $W$, height $H$ and stride $S$ produces an output with $F$ channels
-kernels of total size $W × H × C × F$ and is computed as
+of total size $W × H × C × F$ and is computed as
 $$(⇉I \* ⇉K)\_{i, j, k} = ∑\_{m, n, o} ⇉I\_{i\cdot S + m, j\cdot S + n, o} ⇉K\_{m, n, o, k}.$$
 
 --


### PR DESCRIPTION
I'm not entirely sure what the correct sentence should've been, but "channels kernels" seems wrong.