### PR TITLE
Fix 02.md mistake in MLE formula (wrong signs)

### DIFF
--- a/slides/02/02.md
+++ b/slides/02/02.md
@@ -136,9 +136,9 @@ $$\begin{aligned}
 \argmax\_→θ p(y | →x; →θ) =& \argmin\_→θ ∑\_{i=1}^m -\log p(y^{(i)} | →x^{(i)} ; →θ) \\\
                           =& \argmin\_→θ ∑\_{i=1}^m -\log \sqrt{\frac{1}{2πσ^2}}
                             e ^ {\normalsize -\frac{(y^{(i)} - \hat y(→x^{(i)}; →θ))^2}{2σ^2}} \\\
-                          =& -m \log σ - \frac{m}{2} \log 2π \\\
-                           & - \argmin\_→θ ∑\_{i=1}^m -\frac{(y^{(i)} - \hat y(→x^{(i)}; →θ))^2}{2σ^2} \\\
-                          =& \argmin\_→θ ∑\_{i=1}^m -\frac{||y^{(i)} - \hat y(→x^{(i)}; →θ)||^2}{2σ^2}
+                          =& m \log σ + \frac{m}{2} \log 2π \\\
+                           & + \argmin\_→θ ∑\_{i=1}^m \frac{(y^{(i)} - \hat y(→x^{(i)}; →θ))^2}{2σ^2} \\\
+                          =& \argmin\_→θ ∑\_{i=1}^m \frac{||y^{(i)} - \hat y(→x^{(i)}; →θ)||^2}{2σ^2}
 \end{aligned}$$
 
 ---


### PR DESCRIPTION
I suspect an error in the slides: Most of the minus signs should actually be + signs. In the book (Eq. 5.64, 5.65) there is no minus in front of the probability, but there is in the slides, hence there are double negatives and the signs should be positive. :-) It can be verified manually on a paper. Plus, it would not make sense to argmin -MSE, because that would result in argmax MSE, which is incorrect. I hope I did not make any mistake, I edited the .md manually.