### PR TITLE
small typo fix, simpler formula

### DIFF
--- a/slides/02/02.md
+++ b/slides/02/02.md
@@ -154,7 +154,7 @@ _cross-entropy_ or _Kullback-Leibler divegence_.
 ---
 # Properties of Maximum Likelihood Estimation
 
-Assume that the true data generating distribution $p_\textrm{data}$ lie within the model
+Assume that the true data generating distribution $p_\textrm{data}$ lies within the model
 family $p_\textrm{model}(⋅; →θ)$, and assume there exists a unique
 $→θ_{p_\textrm{data}}$ such that $p_\textrm{data} = p_\textrm{model}(⋅; →θ_{p_\textrm{data}})$.
 
@@ -194,7 +194,7 @@ $$\begin{aligned}
 \argmax_→θ p(y | →x; →θ) =& \argmin_→θ ∑_{i=1}^m -\log p(y^{(i)} | →x^{(i)} ; →θ) \\
                          =& -\argmin_→θ ∑_{i=1}^m \log \sqrt{\frac{1}{2πσ^2}}
                             e ^ {\normalsize -\frac{(y^{(i)} - ŷ(→x^{(i)}; →θ))^2}{2σ^2}} \\
-                         =& -\argmin_→θ {\color{gray} m \log σ^{-1} + m \log (2π)^{-1/2} +}
+                         =& -\argmin_→θ {\color{gray} m \log (2πσ^2)^{-1/2} +}
                             ∑_{i=1}^m -\frac{(y^{(i)} - ŷ(→x^{(i)}; →θ))^2}{2σ^2} \\
                          =& \argmin_→θ ∑_{i=1}^m \frac{(y^{(i)} - ŷ(→x^{(i)}; →θ))^2}{2σ^2} = \argmin_→θ ∑_{i=1}^m (y^{(i)} - ŷ(→x^{(i)}; →θ))^2.
 \end{aligned}$$


### PR DESCRIPTION
Small typo fix + simpler formulation in MLE (no need to split the denominator into two parts). 

I also edited other stuff, but you managed to commit it an hour before I did.