### PR TITLE
Fix note on `model.optimizer.learning_rate`

### DIFF
--- a/labs/02/mnist_training.py
+++ b/labs/02/mnist_training.py
@@ -59,8 +59,8 @@ model = tf.keras.Sequential([
 #   just after the training.
 # In both cases, `decay_steps` should be total number of training batches.
 # If a learning rate schedule is used, you can find out current learning rate
-# by using `model.optimizer.learning_rate(model.optimizer.iterations)`,
-# so after training this value should be `args.learning_rate_final`.
+# by using `model.optimizer.learning_rate`, so after training this value
+# should be `args.learning_rate_final`.
 
 model.compile(
     optimizer=None,


### PR DESCRIPTION
The `model.optimizer.learning_rate` property already returns the LR tensor directly. See https://www.tensorflow.org/versions/r2.0/api_docs/python/tf/optimizers/Optimizer#hyper_parameters
as an example.