### PR TITLE
fix mnist_regularization task assignment

### DIFF
--- a/labs/03/mnist_regularization.py
+++ b/labs/03/mnist_regularization.py
@@ -42,9 +42,9 @@ mnist = MNIST()
 
 # TODO: Implement L2 regularization.
 # If `args.l2` is nonzero, create a `tf.keras.regularizers.L1L2` regularizer
-# and use it for all kernels and biases of all Dense layers. Note that
-# because of a bug if `args.l2` is zero, use `None` instead of `L1L2` regularizer
-# with zero l2.
+# and use it for all kernels and biases of all Dense layers (except the last one).
+# Note that because of a bug if `args.l2` is zero, use `None` instead of `L1L2`
+# regularizer with zero l2.
 
 # TODO: Implement dropout.
 # Add a `tf.keras.layers.Dropout` with `args.dropout` rate after the Flatten

--- a/tasks/mnist_regularization.md
+++ b/tasks/mnist_regularization.md
@@ -11,7 +11,7 @@ template and implement the following:
   output layer).
 - Allow using L2 regularization with weight `args.l2`. Use
   `tf.keras.regularizers.L1L2` as a regularizer for all kernels and biases
-  of all `Dense` layers (including the last one).
+  of all `Dense` layers (except the last one).
 - Allow using label smoothing with weight `args.label_smoothing`. Instead
   of `SparseCategoricalCrossentropy`, you will need to use
   `CategoricalCrossentropy` which offers `label_smoothing` argument.


### PR DESCRIPTION
Code with L2 regularization in the last layer will not get accepted in ReCodEx (accepted if only in hidden layers). This assignment does not specify that it has to be there, but it does in ReCodEx, which is wrong:

> ...  as a regularizer for all kernels and biases of all Dense layers (including the last one).

(sorry if I just misinterpreted the wording and the assignment is actually fine)