### PR TITLE
Fix arXiv citations

### DIFF
--- a/slides/04/vgg_architecture.pdf.ref
+++ b/slides/04/vgg_architecture.pdf.ref
@@ -1,1 +1,1 @@
-Figure 1 of paper "Very Deep Convolutional Networks For Large-Scale Image Recognition", https://arxiv.org/abs/1409.1559.
+Figure 1 of paper "Very Deep Convolutional Networks For Large-Scale Image Recognition", https://arxiv.org/abs/1409.1556.

--- a/slides/04/vgg_inception_results.pdf.ref
+++ b/slides/04/vgg_inception_results.pdf.ref
@@ -1,1 +1,1 @@
-Figure 2 of paper "Very Deep Convolutional Networks For Large-Scale Image Recognition", https://arxiv.org/abs/1409.1559.
+Figure 2 of paper "Very Deep Convolutional Networks For Large-Scale Image Recognition", https://arxiv.org/abs/1409.1556.

--- a/slides/04/vgg_parameters.pdf.ref
+++ b/slides/04/vgg_parameters.pdf.ref
@@ -1,1 +1,1 @@
-Figure 2 of paper "Very Deep Convolutional Networks For Large-Scale Image Recognition", https://arxiv.org/abs/1409.1559.
+Figure 2 of paper "Very Deep Convolutional Networks For Large-Scale Image Recognition", https://arxiv.org/abs/1409.1556.


### PR DESCRIPTION
[arxiv.org/abs/1409.1559](https://arxiv.org/abs/1409.1559) points to 
_Sub-Riemannian and almost-Riemannian geodesics on SO(3) and S^2_, while [arxiv.org/abs/1409.1556](https://arxiv.org/abs/1409.1556) points to _Very Deep Convolutional Networks for Large-Scale Image Recognition_ and even though the first paper surely makes for an interesting read, the second was probably intended.