### PR TITLE
Remove _\theta from the prior p(z)

### DIFF
--- a/slides/10/10.md
+++ b/slides/10/10.md
@@ -73,23 +73,23 @@ By using simple properties of conditional and joint probability, we get that
 $$\begin{aligned}
 𝓛(→θ, →φ;⁇→x) &= 𝔼_{Q_→φ(→z | →x)} [\log P_→θ(→x) + \log P_→θ(→z | →x) - \log Q_→φ(→z | →x)] \\
               &= 𝔼_{Q_→φ(→z | →x)} [\log P_→θ(→x, →z) - \log Q_→φ(→z | →x)] \\
-              &= 𝔼_{Q_→φ(→z | →x)} [\log P_→θ(→x | →z) + \log P_→θ(→z) - \log Q_→φ(→z | →x)] \\
-              &= 𝔼_{Q_→φ(→z | →x)} [\log P_→θ(→x | →z)] - D_\textrm{KL}(Q_→φ(→z | →x) || P_→θ(→z)).
+              &= 𝔼_{Q_→φ(→z | →x)} [\log P_→θ(→x | →z) + \log P(→z) - \log Q_→φ(→z | →x)] \\
+              &= 𝔼_{Q_→φ(→z | →x)} [\log P_→θ(→x | →z)] - D_\textrm{KL}(Q_→φ(→z | →x) || P(→z)).
 \end{aligned}$$
 
 ---
 # Variational AutoEncoders
-$$ 𝓛(→θ, →φ;⁇→x) = 𝔼_{Q_→φ(→z | →x)} [\log P_→θ(→x | →z)] - D_\textrm{KL}(Q_→φ(→z | →x) || P_→θ(→z))$$
+$$ 𝓛(→θ, →φ;⁇→x) = 𝔼_{Q_→φ(→z | →x)} [\log P_→θ(→x | →z)] - D_\textrm{KL}(Q_→φ(→z | →x) || P(→z))$$
 
 We train a VAE by maximizing $𝓛(→θ, →φ;⁇→x)$, taking a single point estimate of the expectation and using
-a prior $P_→θ(→z) = 𝓝(0, 1)$.
+a prior $P(→z) = 𝓝(0, 1)$.
 
 ~~~
 Note that the loss has 2 intuitive components:
 - reconstruction loss: Starting with $→x$, and passing though $Q$ and then again
   through $P$ should arrive back at $→x$.
 ~~~
-- latent loss: The distribution of $Q_→φ(→z | →x)$ should be as close to the prior $P_→θ(→z) = 𝓝(0, 1)$,
+- latent loss: The distribution of $Q_→φ(→z | →x)$ should be as close to the prior $P(→z) = 𝓝(0, 1)$,
   which is independent on $→x$.
 
 ---


### PR DESCRIPTION
Since $P(z)$ is the prior (and slide 9 even says $P(z) = N(0, 1)$) it does depend on the parameters θ.

It would make sense to talk about something like $P_θ(x) = E_{z\~P(z)} [P_θ(x | z)]$, because then the marginal likelihood is computed as a function of the parameterized decoder $P_θ(x | z)$ (and a fixed prior), or possibly even something like $Q_phi(z) = E_x~P(x) [Q_phi(z | x)]$, as those are both a function of the parameters, but the latent prior distribution is not.