### PR TITLE
Removed linalg from the hint

### DIFF
--- a/labs/01/pca_first.py
+++ b/labs/01/pca_first.py
@@ -61,7 +61,7 @@ def main(args: argparse.Namespace) -> Tuple[float, float]:
         # 1. v = cov * v
         #    The matrix-vector multiplication can be computed using `tf.linalg.matvec`.
         # 2. s = l2_norm(v)
-        #    The l2_norm can be computed using `tf.linalg.norm`.
+        #    The l2_norm can be computed using `tf.norm`.
         # 3. v = v / s
         pass
 


### PR DESCRIPTION
tf.linalg.norm still works (as an alias) but it has been changed to tf.norm, even on the webpage, the alias is hidden behind a click. Nitpicking, but will probably help someone who will struggle to find the parameters for the function.