### PR TITLE
lemmatizer_noattn.py typo

### DIFF
--- a/labs/09/lemmatizer_noattn.py
+++ b/labs/09/lemmatizer_noattn.py
@@ -154,7 +154,7 @@ class Model(tf.keras.Model):
         # TODO: Embed source_charseqs using `source_embedding`.
 
         # TODO: Run source_rnn on the embedded sequences, returning outputs in `source_states`.
-        sources_states = None
+        source_states = None
 
         # Run the appropriate decoder. Note that the outputs of the decoders
         # are exactly the outputs of `tfa.seq2seq.dynamic_decode`.


### PR DESCRIPTION
TODO states "Run source_rnn on the embedded sequences, returning outputs in `source_states`", current template has variable "sources_states". Either the variable name should be changed (my commit), or the TODO message.