### PR TITLE
Fix typo in lemmatizer_attn and lemmatizer_noattn

### DIFF
--- a/labs/09/lemmatizer_attn.py
+++ b/labs/09/lemmatizer_attn.py
@@ -190,7 +190,7 @@ class Model(tf.keras.Model):
         # However, convert the embedded sequences from a RaggedTensor to a dense Tensor first,
         # i.e., call the `source_rnn` with
         #   (source_embedded.to_tensor(), mask=tf.sequence_mask(source_embedded.row_lengths()))
-        sources_states = None
+        source_states = None
 
         # Run the appropriate decoder. Note that the outputs of the decoders
         # are exactly the outputs of `tfa.seq2seq.dynamic_decode`.

--- a/labs/09/lemmatizer_noattn.py
+++ b/labs/09/lemmatizer_noattn.py
@@ -154,7 +154,7 @@ class Model(tf.keras.Model):
         # TODO: Embed source_charseqs using `source_embedding`.
 
         # TODO: Run source_rnn on the embedded sequences, returning outputs in `source_states`.
-        sources_states = None
+        source_states = None
 
         # Run the appropriate decoder. Note that the outputs of the decoders
         # are exactly the outputs of `tfa.seq2seq.dynamic_decode`.


### PR DESCRIPTION
All comments seem to mention `source_states`, not `sources_states`, so I guess it's a typo. Feel free to squash-merge the PR, there two commits because I was too lazy to clone the repo locally :|