### PR TITLE
Better description for decoder activation function

### DIFF
--- a/labs/12/vae.py
+++ b/labs/12/vae.py
@@ -51,7 +51,7 @@ class VAE(tf.keras.Model):
         # - applies `len(args.decoder_layers)` dense layers with ReLU activation,
         #   i-th layer with `args.decoder_layers[i]` units
         # - applies output dense layer with `MNIST.H * MNIST.W * MNIST.C` units
-        #   and a suitable output activation
+        #   and a sigmoid output activation
         # - reshapes the output (`tf.keras.layers.Reshape`) to `[MNIST.H, MNIST.W, MNIST.C]`
         self.decoder = None
 


### PR DESCRIPTION
Sigmoid is an obvious choice here for pixels from [0, 1], right?

In gan.py, sigmoid is explicitly stated

EDIT: I have checked and in gan.py, the phrase "suitable activation function" is as well, it makes a little more sense there since discriminator is "classifying", whereas we can use e.g. MSE as a reconstruction error in VAEs, right?