### PR TITLE
Small fixes in slides and exam questions

### DIFF
--- a/exam/questions.md
+++ b/exam/questions.md
@@ -107,7 +107,7 @@
 
 - Describe the CNN regularization method of networks with stochastic depth. [5]
 
-- Compare Cutout and BlockDrop. [5]
+- Compare Cutout and DropBlock. [5]
 
 - Describe Squeeze and Excitation applied to a ResNet block. [5]
 

--- a/slides/05/05.md
+++ b/slides/05/05.md
@@ -332,7 +332,7 @@ activation by $p_l$ during training only.
 
 ~~~
 All $p_l$ can be set to a constant, but more effective approach is to utilize
-a simple linear decay $p_l = 1 - l/L(1-p_L)$, where $p_L$ is the final
+a simple linear decay $p_l = 1 - \frac{l}{L}(1-p_L)$, where $p_L$ is the final
 probability of the last layer, motivated by the intuition that the initial
 blocks extract low-level features utilized by the later layers, and should
 therefore be present.

--- a/slides/05/05.md
+++ b/slides/05/05.md
@@ -356,7 +356,7 @@ According to the ablation experiments, linear decay with $p_L=0.5$ was selected.
 ![w=60%,h=center](cutout_examples.svgz)
 
 Drop $16×16$ square in the input image, with randomly chosen center.
-The pixels are replaced by a their mean value from the dataset.
+The pixels are replaced by their mean value from the dataset.
 
 ---
 # Cutout

--- a/slides/06/06.md
+++ b/slides/06/06.md
@@ -299,7 +299,7 @@ Straightforward extension of Faster R-CNN able to produce image segmentation
 
 More precise alignment is required for the RoI in order to predict the masks.
 Instead of quantization and max-pooling in RoI pooling, **RoIAlign** uses bilinear
-interpolation of features at four regularly samples locations in each RoI bin
+interpolation of features at four regularly sampled locations in each RoI bin
 and averages them.
 
 ![w=68%,mw=50%,h=center](roi_pooling.svgz)![w=68%,mw=50%,h=center](mask_rcnn_roialign.svgz)


### PR DESCRIPTION
Dobrý den,

dovolil jsem si změnit jednu testovou otázku ;) a vyřešit dvě typos ve slidech.

Také navrhuji, změnit `$p_l = 1 - l/L(1-p_L)$` na `$p_l = 1 - \frac{l}{L}(1-p_L)$`. Myslím, že je to tak srozumitelnější. Mně se totiž na poprvé podařilo výše zmíněné přečíst jako `$p_l = 1 - l/(L(1-p_L))$` a později jsem se zarazil, že to takhle nemůže dávat smysl a musím v tom mít chybu.

PS: Body mi netřeba dávat. Jednak jich je dost a druhak mi přijde, že jsem ty předchozí dostal za dost triviální opravy a nechci je nesmyslně hromadit.