### PR TITLE
Fix link to PDF slides in lectures

### DIFF
--- a/lectures/lecture01.md
+++ b/lectures/lecture01.md
@@ -1,7 +1,7 @@
 ### Lecture: 1. Introduction to Deep Learning
 #### Date: Feb 13
 #### Slides: https://ufal.mff.cuni.cz/~straka/courses/npfl114/2223/slides/?01
-#### Reading: https://ufal.mff.cuni.cz/~straka/courses/npfl114/2223/slides.pdf/npfl114-2223-01.pdf,PDF Slides
+#### Reading: https://ufal.mff.cuni.cz/~straka/courses/npfl114/2223/slides.pdf/npfl114-2223-01.pdf, PDF Slides
 #### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl114/2223/npfl114-2223-01-czech.mp4, CZ Lecture
 #### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl114/2223/npfl114-2223-01-czech.practicals.mp4, CZ Practicals
 #### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl114/2223/npfl114-2223-01-english.mp4, EN Lecture

--- a/lectures/lecture02.md
+++ b/lectures/lecture02.md
@@ -1,7 +1,7 @@
 ### Lecture: 2. Training Neural Networks
 #### Date: Feb 20
 #### Slides: https://ufal.mff.cuni.cz/~straka/courses/npfl114/2223/slides/?02
-#### Reading: https://ufal.mff.cuni.cz/~straka/courses/npfl114/2223/slides.pdf/npfl114-2223-02.pdf,PDF Slides
+#### Reading: https://ufal.mff.cuni.cz/~straka/courses/npfl114/2223/slides.pdf/npfl114-2223-02.pdf, PDF Slides
 #### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl114/2223/npfl114-2223-02-czech.mp4, CZ Lecture
 #### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl114/2223/npfl114-2223-02-czech.practicals.mp4, CZ Practicals
 #### Video: https://lectures.ms.mff.cuni.cz/video/rec/npfl114/2223/npfl114-2223-02-english.mp4, EN Lecture

--- a/lectures/lecture03.md
+++ b/lectures/lecture03.md
@@ -1,7 +1,7 @@
 ### Lecture: 3. Training Neural Networks II
 #### Eate: Feb 27
 #### Slides: https://ufal.mff.cuni.cz/~straka/courses/npfl114/2223/slides/?03
-#### Reading: https://ufal.mff.cuni.cz/~straka/courses/npfl114/2223/slides.pdf/npfl114-2223-03.pdf,PDF Slides
+#### Reading: https://ufal.mff.cuni.cz/~straka/courses/npfl114/2223/slides.pdf/npfl114-2223-03.pdf, PDF Slides
 #### Questions: #lecture_3_questions
 #### Lecture assignment: mnist_regularization
 #### Lecture assignment: mnist_ensemble


### PR DESCRIPTION
The links didn't work due to a missing space. It's probably an issue in some script that generates the files.